### PR TITLE
Add hugepage resource reqs

### DIFF
--- a/k8s/hello-world-enclave-pod.yaml
+++ b/k8s/hello-world-enclave-pod.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: hello-world-enclave
-  #annotations:
-  #  seccomp.security.alpha.kubernetes.io/pod: unconfined
 spec:
   containers:
     - name: nitro-cli
@@ -12,11 +10,6 @@ spec:
       # the container and just try "run.sh"
       command: ["/enclave/sleep.sh"]
       imagePullPolicy: Always
-      #securityContext:
-      #  allowPrivilegeEscalation: true
-      #  privileged: true
-      #  capabilities:
-      #    add: ["SYS_ADMIN"]
       ports:
         # TODO: socat the enclave console to some port
         - name: console
@@ -25,21 +18,27 @@ spec:
       resources:
         limits:
           smarter-devices/nitro_enclaves: "1"
-          cpu: 1000m
-          memory: 512Mi
+          hugepages-2Mi: 512Mi
+          memory: 2Gi
         requests:
           smarter-devices/nitro_enclaves: "1"
-          cpu: 10m
-          memory: 50Mi
-      #volumeMounts:
-      #- name: dockersock
-      #  mountPath: "/var/run/docker.sock"
+          hugepages-2Mi: 512Mi
+      volumeMounts:
+      - name: dockersock
+        mountPath: "/var/run/docker.sock"
+      - mountPath: /dev/hugepages
+        name: hugepage
+        readOnly: false
   tolerations:
   - effect: NoSchedule
     operator: Exists
   - effect: NoExecute
     operator: Exists
-  #volumes:
-  #  - name: dockersock
-  #    hostPath:
-  #      path: /var/run/docker.sock
+  volumes:
+    - name: dockersock
+      hostPath:
+        path: /var/run/docker.sock
+    - name: hugepage
+      emptyDir:
+        medium: HugePages
+


### PR DESCRIPTION
Nitro allocates hugepages equal in size to the RAM allocated to the enclave. By default, K8s doesn't allow pods to write to hugepages. These changes add the hugepage volume mount, limits, and requests, all of which are required for hugepages to work in a pod. 